### PR TITLE
Add optional nlms parameter to incremental learning functions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "discriminative_lexicon_model"
-version = "2.2.0"
+version = "2.3.0"
 description = "Python-implementation of Discriminative Lexicon Model / Linear Discriminative Learning"
 
 license = "MIT"


### PR DESCRIPTION
## Summary

- Adds an `nlms` parameter to control whether the Normalized Least Mean Squares (NLMS) algorithm is used for weight updates
- NLMS is enabled by default (`nlms=True`) for numerical stability
- Users can disable it (`nlms=False`) to use the standard LMS algorithm

## Motivation

The NLMS algorithm normalizes weight updates by the squared norm of the cue vector, providing more stable learning rates across different input magnitudes. However, some use cases may require the standard LMS behavior, so this change makes the normalization optional while keeping NLMS as the default.

## Changes

- `incremental_learning`: Added `nlms` parameter with documentation
- `_incremental_learning_numpy`: Added `nlms` parameter
- `_incremental_learning_torch`: Added `nlms` parameter
- `update_weight_matrix`: Added `nlms` parameter
- `delta_weight_matrix`: Added `nlms` parameter

## Usage

```python
# Default behavior (NLMS enabled for numerical stability)
weights = incremental_learning(rows, cue_matrix, out_matrix)

# Disable NLMS to use standard LMS algorithm
weights = incremental_learning(rows, cue_matrix, out_matrix, nlms=False)
```
