### PR TITLE
Add GPU support to gen_shat via PyTorch backend

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "discriminative_lexicon_model"
-version = "2.3.0"
+version = "2.4.0"
 description = "Python-implementation of Discriminative Lexicon Model / Linear Discriminative Learning"
 
 license = "MIT"


### PR DESCRIPTION
## Summary

- Add optional GPU acceleration to `gen_shat()` using PyTorch
- Bump version to 2.4.0

## Changes

### New parameters for `gen_shat()`

- `backend`: Computation backend - `'numpy'`, `'torch'`, or `'auto'` (default)
  - `'auto'` uses PyTorch with CUDA if available, otherwise falls back to NumPy
- `device`: Device for torch backend - `'cuda'`, `'cpu'`, or `None` (auto-detect)

### Code improvements

- Refactored to reduce code duplication across the three input combinations (C+F, C+S, H+S)
- Added docstring with parameter documentation

## Backward compatibility

Fully backward compatible. Existing code calling `gen_shat(cmat=..., fmat=...)` works unchanged. The default `backend='auto'` transparently uses GPU when available.

## Example usage

```python
# Auto-detect (uses GPU if available)
shat = gen_shat(cmat=cmat, fmat=fmat)

# Force GPU
shat = gen_shat(cmat=cmat, fmat=fmat, backend='torch', device='cuda')

# Force CPU (NumPy)
shat = gen_shat(cmat=cmat, fmat=fmat, backend='numpy')
```
