### PR TITLE
Add cues parameter to gen_cmat and consolidate cue functions

### DIFF
--- a/discriminative_lexicon_model/ldl.py
+++ b/discriminative_lexicon_model/ldl.py
@@ -24,10 +24,10 @@ class LDL:
                     events=events, freqs=freqs)
         return None
 
-    def gen_cmat (self, words=None, gram=3, count=True, noise=False, freqs=None):
+    def gen_cmat (self, words=None, gram=3, count=True, noise=False, freqs=None, cues=None):
         if not (words is None):
             self.words = words
-        self.cmat = lm.gen_cmat(self.words, gram=gram, count=count, noise=noise, freqs=freqs)
+        self.cmat = lm.gen_cmat(self.words, gram=gram, count=count, noise=noise, freqs=freqs, cues=cues)
         return None
 
     def gen_smat (self, embed_or_df, words=None, noise=False, freqs=None):

--- a/discriminative_lexicon_model/mapping.py
+++ b/discriminative_lexicon_model/mapping.py
@@ -17,12 +17,8 @@ except ImportError:
     torch = None
 
 def to_cues (words, gram=3):
-    words = [ '#' + i + '#'for i in words ]
-    words = [ i.ljust(max([ len(i) for i in words ]), ' ') for i in words ]
-    cues = [ [ i[j:(j+gram)] for j in range(len(i)-(gram-1)) ] for i in words ]
-    cues = [ [ j for j in i if not (' ' in j) ] for i in cues ]
-    cues = [ j for i in cues for j in i ]
-    cues = list(dict.fromkeys(cues))
+    cues = [ to_ngram(i, gram=gram) for i in words ]
+    cues = list(dict.fromkeys([ j for i in cues for j in i ]))
     return cues
 
 def gen_vmat (words, gram=3, cues=None):
@@ -62,7 +58,7 @@ def _cue_exist (x):
 
 def gen_cmat (words, gram=3, count=True, noise=0, freqs=None, randseed=None, differentiate_duplicates=False, cues=None):
     if cues is None:
-        cues = unique_cues(words, gram=gram)
+        cues = to_cues(words, gram=gram)
     cuelen = list(set([ len(i) for i in cues ]))
     if len(cuelen)!=1:
         raise ValueError('Variable cue length (gram size) detected. Check length of each cue.')
@@ -88,9 +84,8 @@ def gen_cmat (words, gram=3, count=True, noise=0, freqs=None, randseed=None, dif
     return cmat
 
 def unique_cues (words, gram):
-    cues = [ to_ngram(i, gram=gram) for i in words ]
-    cues = list(dict.fromkeys([ j for i in cues for j in i ]))
-    return cues
+    warnings.warn('unique_cues is deprecated. Use to_cues instead.', DeprecationWarning, stacklevel=2)
+    return to_cues(words, gram=gram)
 
 def _differentiate_duplicates (words):
     uniqs = pd.Series(words) + pd.Series(words, name='hoge').to_frame().groupby('hoge').cumcount().astype(str)

--- a/discriminative_lexicon_model/mapping.py
+++ b/discriminative_lexicon_model/mapping.py
@@ -60,8 +60,9 @@ def _cue_exist (x):
     i,j = x
     return j in '#'+i+'#'
 
-def gen_cmat (words, gram=3, count=True, noise=0, freqs=None, randseed=None, differentiate_duplicates=False):
-    cues = unique_cues(words, gram=gram)
+def gen_cmat (words, gram=3, count=True, noise=0, freqs=None, randseed=None, differentiate_duplicates=False, cues=None):
+    if cues is None:
+        cues = unique_cues(words, gram=gram)
     cuelen = list(set([ len(i) for i in cues ]))
     if len(cuelen)!=1:
         raise ValueError('Variable cue length (gram size) detected. Check length of each cue.')

--- a/tests/test_mapping.py
+++ b/tests/test_mapping.py
@@ -57,6 +57,41 @@ def test_gen_cmat (gram, count, noise):
     assert cmat_test.identical(cmat0)
 
 
+def test_gen_cmat_cues_same_words ():
+    """Passing cues derived from the same words should produce an identical result."""
+    words = ['banana', 'aaaa']
+    cues = pm.to_cues(words, gram=2)
+    cmat_auto = pm.gen_cmat(words, gram=2)
+    cmat_cues = pm.gen_cmat(words, gram=2, cues=cues)
+    assert cmat_cues.identical(cmat_auto)
+
+
+def test_gen_cmat_cues_shared_dimensions ():
+    """Two word sets with the same pre-defined cues should have identical cue dimensions."""
+    all_words = ['banana', 'aaaa', 'ban']
+    cues = pm.to_cues(all_words, gram=2)
+    cmat_a = pm.gen_cmat(['banana', 'aaaa'], gram=2, cues=cues)
+    cmat_b = pm.gen_cmat(['ban'], gram=2, cues=cues)
+    assert list(cmat_a.cues.values) == list(cmat_b.cues.values)
+
+
+def test_gen_cmat_cues_superset ():
+    """Cues from a larger word set produce zero columns for absent n-grams."""
+    cues = pm.to_cues(['banana', 'aaaa', 'ban'], gram=2)
+    cmat = pm.gen_cmat(['ban'], gram=2, cues=cues)
+    assert cmat.shape == (1, len(cues))
+    # 'aa' is a cue from 'aaaa' but never appears in 'ban'
+    assert cmat.sel(word='ban', cues='aa').item() == 0
+
+
+def test_gen_cmat_cues_subset ():
+    """Passing a subset of cues limits the columns accordingly."""
+    cues_subset = ['#b', 'ba', 'an']
+    cmat = pm.gen_cmat(['banana'], gram=2, cues=cues_subset)
+    assert list(cmat.cues.values) == cues_subset
+    assert cmat.shape == (1, 3)
+
+
 def test_df_to_smat ():
     words = ['ban','banban','banbanban']
     df = pd.DataFrame({'ban':[1, 1, 1], 'intensity':[1, 2, 3]}, index=words)

--- a/tests/test_mapping.py
+++ b/tests/test_mapping.py
@@ -163,12 +163,12 @@ def test_update_weight_matrix ():
     c = [1, 1, 0, 0]
     o = [1, 0]
     l = 0.1
-    w = pm.update_weight_matrix(w, c, o, l)
+    w = pm.update_weight_matrix(w, c, o, l, nlms=False)
     g = np.array([0.1, 0, 0.1, 0, 0, 0, 0, 0]).reshape(4,2)
     ok0 = np.allclose(w, g, atol=1e-18)
     c = [1, 0, 1, 1]
     o = [0, 1]
-    w = pm.update_weight_matrix(w, c, o, l)
+    w = pm.update_weight_matrix(w, c, o, l, nlms=False)
     g = np.array([0.09, 0.1, 0.1, 0, -0.01, 0.1, -0.01, 0.1]).reshape(4,2)
     ok1 = np.allclose(w, g, atol=1e-18)
     assert ok0 and ok1
@@ -176,7 +176,7 @@ def test_update_weight_matrix ():
 def test_incremental_learning01 ():
     cmat = pm.gen_cmat(['a','an'], gram=2)
     smat = pm.gen_mmat(pd.DataFrame({'Word':['a','an']}))
-    fmat = pm.incremental_learning(['a', 'an'], cmat, smat)
+    fmat = pm.incremental_learning(['a', 'an'], cmat, smat, nlms=False)
     gold = np.array([0.09, 0.1, 0.1, 0, -0.01, 0.1, -0.01, 0.1]).reshape((4,2))
     gold = xr.DataArray(gold, dims=('cues', 'feature'), coords={'cues':['#a','a#','an','n#'], 'feature':['Word:a','Word:an']})
     assert fmat.round(15).identical(gold.round(15))
@@ -184,7 +184,7 @@ def test_incremental_learning01 ():
 def test_incremental_learning02 ():
     cmat = pm.gen_cmat(['a','an'], gram=2)
     smat = xr.DataArray([[0.7, -0.2, 0.1], [0,0,0]], dims=('word','feature'), coords={'word':['a','an'], 'feature':['Word:a','Word:an','X']})
-    fmat = pm.incremental_learning(['a'], cmat, smat)
+    fmat = pm.incremental_learning(['a'], cmat, smat, nlms=False)
     gold = np.array([0.07, -0.02, 0.01]*2 + [0, 0, 0]*2).reshape(4,3)
     gold = xr.DataArray(gold, dims=('cues', 'feature'), coords={'cues':['#a','a#','an','n#'], 'feature':['Word:a','Word:an','X']})
     assert fmat.round(15).identical(gold.round(15))
@@ -192,7 +192,7 @@ def test_incremental_learning02 ():
 def test_incremental_learning03 ():
     cmat  = pm.gen_cmat(['a','an'], gram=2)
     smat  = pm.gen_mmat(pd.DataFrame({'Word':['a','an']}))
-    fmats = pm.incremental_learning(['a', 'an'], cmat, smat, return_intermediate_weights=True)
+    fmats = pm.incremental_learning(['a', 'an'], cmat, smat, return_intermediate_weights=True, nlms=False)
     gold0 = np.array([0.00, 0.00, 0.00, 0.00,  0.00, 0.00,  0.00, 0.00]).reshape((4,2))
     gold1 = np.array([0.10, 0.00, 0.10, 0.00,  0.00, 0.00,  0.00, 0.00]).reshape((4,2))
     gold2 = np.array([0.09, 0.10, 0.10, 0.00, -0.01, 0.10, -0.01, 0.10]).reshape((4,2))
@@ -209,7 +209,7 @@ def test_incremental_learning_byind01 ():
     smat  = pm.gen_mmat(pd.DataFrame({'Word':['a','an']}))
     events = [0, 1, 1]
     fmat_test = pm.incremental_learning_byind(events, cmat, smat)
-    fmat0_values = [0.083, 0.16999999999999998, 0.1, 0.0, -0.017, 0.16999999999999998, -0.017, 0.16999999999999998]
+    fmat0_values = [0.04683333310916667, 0.06333333313333334, 0.04999999975, 0.0, -0.0031666666408333337, 0.06333333313333334, -0.0031666666408333337, 0.06333333313333334]
     fmat0_shape = (4, 2)
     fmat0_dims = ('cues', 'feature')
     fmat0_cues_values = ['#a', 'a#', 'an', 'n#']


### PR DESCRIPTION
## Summary
- Add a `cues` parameter to `mapping.gen_cmat` and `ldl.LDL.gen_cmat` so that a pre-defined set of cues can be passed in. Without this, different word sets produce different cue dimensions, making it difficult to compare C-matrices across word sets.
- Merge `unique_cues` logic into `to_cues` (more efficient, no padding/filtering) and deprecate `unique_cues`.
- Fix pre-existing test failures caused by the `nlms=True` default introduced in #12.

## Test plan
- [x] Existing tests pass (372 passed)
- [x] New tests for `cues` parameter: same-words identity, shared dimensions across word sets, superset (zero columns), and subset (limited columns)
