### PR TITLE
Define public API surface via __all__ and enable flat imports

### DIFF
--- a/discriminative_lexicon_model/__init__.py
+++ b/discriminative_lexicon_model/__init__.py
@@ -21,8 +21,17 @@ except ModuleNotFoundError:
 try:
     from . import mapping
     from . import measures
-    from . import performance 
+    from . import performance
     from . import ldl
+    from .mapping import *
+    from .measures import *
+    from .performance import *
+    from .ldl import *
 except ModuleNotFoundError:
     pass
+
+__all__ = ["mapping", "measures", "performance", "ldl"]
+for _mod in (mapping, measures, performance, ldl):
+    __all__ += getattr(_mod, "__all__", [])
+del _mod
 

--- a/discriminative_lexicon_model/ldl.py
+++ b/discriminative_lexicon_model/ldl.py
@@ -6,6 +6,8 @@ from pathlib import Path
 from . import mapping as lm
 from . import performance as lp
 
+__all__ = ["LDL"]
+
 try:
     import torch
 except ImportError:

--- a/discriminative_lexicon_model/mapping.py
+++ b/discriminative_lexicon_model/mapping.py
@@ -11,6 +11,31 @@ from tqdm import tqdm
 
 from . import mapping as lmap
 
+__all__ = [
+    "to_cues",
+    "to_ngram",
+    "infer_gram",
+    "gen_vmat",
+    "gen_cmat",
+    "gen_cmat_from_df",
+    "gen_smat",
+    "gen_smat_from_df",
+    "gen_smat_sim",
+    "gen_mmat",
+    "gen_jmat",
+    "gen_fmat",
+    "gen_gmat",
+    "gen_shat",
+    "gen_chat",
+    "incremental_learning",
+    "weight_by_freq",
+    "save_mat_as_csv",
+    "load_mat_from_csv",
+    "load_csv",
+    "save_mat",
+    "load_mat",
+]
+
 try:
     import torch
 except ImportError:

--- a/discriminative_lexicon_model/measures.py
+++ b/discriminative_lexicon_model/measures.py
@@ -4,6 +4,16 @@ import scipy.spatial.distance as spd
 
 from . import mapping as pmap
 
+__all__ = [
+    "functional_load",
+    "partial_semantic_support",
+    "semantic_support",
+    "semantic_support_word",
+    "prod_acc",
+    "uncertainty",
+    "vector_length",
+]
+
 def functional_load (cue, fmat, word, smat, method='corr'):
     cvec = fmat.loc[cue,:]
     wvec = smat.loc[word,:]

--- a/discriminative_lexicon_model/performance.py
+++ b/discriminative_lexicon_model/performance.py
@@ -3,6 +3,8 @@ import pandas as pd
 import xarray as xr
 import scipy.spatial.distance as spd
 
+__all__ = ["accuracy", "predict_df", "distance_matrix"]
+
 def accuracy (*, pred, gold, method='correlation'):
     """
     Calculates prediction accuracy from a matrix of predictions and that of

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "discriminative_lexicon_model"
-version = "2.4.0"
+version = "2.5.0"
 description = "Python-implementation of Discriminative Lexicon Model / Linear Discriminative Learning"
 
 license = "MIT"


### PR DESCRIPTION
## Summary
- Add `__all__` to `mapping`, `measures`, `performance`, `ldl`, and `__init__` to formally separate public API from internal helpers
- Re-export all public names at the package level, enabling `import discriminative_lexicon_model as dlm; dlm.gen_cmat(...)` without reaching into submodules
- Bump version to 2.5.0

## Details

Previously, all functions — including internal utilities (`matmul`, `is_xarray`, etc.), deprecated wrappers (`unique_cues`, `incremental_learning_byind`), and low-level helpers — were equally visible. This made it hard for users to know what is stable public API vs. implementation detail.

Each submodule now defines `__all__` listing only its public API:
- **mapping** (22 functions): `gen_cmat`, `gen_smat`, `gen_fmat`, `gen_shat`, `gen_chat`, `incremental_learning`, etc.
- **measures** (7 functions): `functional_load`, `semantic_support`, `prod_acc`, `uncertainty`, etc.
- **performance** (3 functions): `accuracy`, `predict_df`, `distance_matrix`
- **ldl** (1 class): `LDL`

Internal helpers remain importable via their full path (e.g., `discriminative_lexicon_model.mapping.matmul`) but are excluded from `__all__` and the package-level namespace.

## Test plan
- [x] `python -m pytest` — all 376 tests pass
- [x] `import discriminative_lexicon_model as dlm; dlm.gen_cmat` resolves correctly
- [x] `from discriminative_lexicon_model.mapping import *` only imports public names
- [x] Internal helpers (e.g., `matmul`, `is_xarray`) are not promoted to package level
