### PR TITLE
Add concat_cues to ldl __all__

### DIFF
--- a/discriminative_lexicon_model/ldl.py
+++ b/discriminative_lexicon_model/ldl.py
@@ -6,7 +6,10 @@ from pathlib import Path
 from . import mapping as lm
 from . import performance as lp
 
-__all__ = ["LDL"]
+__all__ = [
+    "LDL",
+    "concat_cues",
+]
 
 try:
     import torch

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "discriminative_lexicon_model"
-version = "2.5.0"
+version = "2.5.1"
 description = "Python-implementation of Discriminative Lexicon Model / Linear Discriminative Learning"
 
 license = "MIT"


### PR DESCRIPTION
`concat_cues` was omitted from `ldl.__all__` when the public API surface was defined in #15. This means it is not re-exported at the package level, so `dlm.concat_cues` raises an `AttributeError`.

Add it to `__all__` so the function is accessible through the flat import path like the other public functions. Bump version to 2.5.1.
