### PR TITLE
Improve produce: add stop/tol parameters, deduplicate code, fix cue concatenation

### DIFF
--- a/discriminative_lexicon_model/ldl.py
+++ b/discriminative_lexicon_model/ldl.py
@@ -125,25 +125,10 @@ class LDL:
             For torch backend: 'cuda', 'cpu', etc. If None and backend is
             'torch' or 'auto', chooses 'cuda' if available, else 'cpu'.
         """
-        # Determine which backend to use
-        use_torch = False
-        if backend == 'torch':
-            if torch is None:
-                raise ImportError('PyTorch is not installed. Install it to use the "torch" backend.')
-            use_torch = True
-            if device is None:
-                device = 'cuda' if torch.cuda.is_available() else 'cpu'
-        elif backend == 'auto':
-            if torch is not None and (device == 'cuda' or (device is None and torch.cuda.is_available())):
-                use_torch = True
-                device = device or 'cuda'
-        elif backend != 'numpy':
-            raise ValueError(f'Unknown backend "{backend}". Use "numpy", "torch", or "auto".')
-
-        if use_torch:
-            return self._produce_torch(gold, word, roundby, max_attempt, positive, apply_vmat, device)
-        else:
-            return self._produce_numpy(gold, word, roundby, max_attempt, positive, apply_vmat)
+        return lm.produce(gold, self.cmat, self.fmat, self.gmat, self.vmat,
+                          word=word, roundby=roundby, max_attempt=max_attempt,
+                          positive=positive, apply_vmat=apply_vmat,
+                          backend=backend, device=device)
 
     def produce_batch (self, gold_batch, word=False, roundby=10, max_attempt=50, positive=False, apply_vmat=True, backend='auto', device=None, batch_size=None):
         """
@@ -196,63 +181,11 @@ class LDL:
         if use_torch:
             return self._produce_batch_torch(gold_batch, word, roundby, max_attempt, positive, apply_vmat, device, batch_size)
         else:
-            # Fallback to sequential processing with NumPy
+            # Fallback to sequential processing
             results = []
             for gold in gold_batch:
-                results.append(self._produce_numpy(gold, word, roundby, max_attempt, positive, apply_vmat))
+                results.append(self.produce(gold, word=word, roundby=roundby, max_attempt=max_attempt, positive=positive, apply_vmat=apply_vmat, backend='numpy'))
             return results
-
-    def _produce_numpy (self, gold, word, roundby, max_attempt, positive, apply_vmat):
-        """NumPy implementation of produce (original CPU version)."""
-        if not isinstance(gold, np.ndarray):
-            gold = np.array(gold, dtype=np.float32)
-        else:
-            gold = gold.astype(np.float32)
-        p = -1
-        xs = []
-        vecs = []
-        cues_values = self.cmat.cues.values
-        fmat_values = self.fmat.values.astype(np.float32)
-        gmat_values = self.gmat.values.astype(np.float32)
-        if apply_vmat:
-            vmat_values = self.vmat.values.astype(np.float32)
-            vmat_current_values = self.vmat.current.values
-        c_comp = np.zeros(cues_values.size, dtype=np.float32)
-        for i in range(max_attempt):
-            s0 = np.matmul(c_comp, fmat_values)
-            if positive:
-                s0[s0<0] = 0 # It may be necessary for a small lexicon with multi-hot matrices.
-            s = gold - s0
-            if apply_vmat:
-                # Element-wise multiplication instead of np.diag() matrix multiplication
-                vmat_row = vmat_values[p]
-                g = gmat_values * vmat_row
-            else:
-                g = gmat_values
-            c_prod = np.matmul(s, g)
-            # c_prod[c_prod<0] = 0  # It may be necessary for a small lexicon with multi-hot matrices.
-            if (c_prod<=0).all():
-                break
-            else:
-                p = np.argmax(c_prod)
-                c_comp[p] = c_comp[p] + 1
-                xs.append(cues_values[p])
-                vecs.append(c_prod)
-            is_unigram_onset = len(xs)==1 and len(xs[0])==1 and xs[0]=='#'
-            is_end = (xs[-1][-1]=='#') and (not is_unigram_onset)
-            is_max_iter = i==(max_attempt-1)
-            if is_end or is_max_iter:
-                if is_max_iter:
-                    print('The maximum number of iterations ({:d}) reached.'.format(max_attempt))
-                break
-        # Round vectors only at the end, not in every iteration
-        vecs = [v.round(roundby) for v in vecs]
-        df = pd.DataFrame(vecs).rename(columns={ i:j for i,j in enumerate(cues_values) })
-        hdr = pd.Series(xs).to_frame(name='Selected')
-        df = pd.concat([hdr, df], axis=1)
-        if word:
-            df = concat_cues(df.Selected)
-        return df
 
     def _produce_batch_torch (self, gold_batch, word, roundby, max_attempt, positive, apply_vmat, device, batch_size):
         """
@@ -373,90 +306,6 @@ class LDL:
             results.append(df)
 
         return results
-
-    def _produce_torch (self, gold, word, roundby, max_attempt, positive, apply_vmat, device):
-        """PyTorch implementation of produce with GPU support (Phase 1 optimizations)."""
-        if not isinstance(gold, np.ndarray):
-            gold = np.array(gold)
-
-        # Move data to torch tensors on specified device
-        gold_tensor = torch.as_tensor(gold, dtype=torch.float32, device=device)
-        fmat_tensor = torch.as_tensor(self.fmat.values, dtype=torch.float32, device=device)
-        gmat_tensor = torch.as_tensor(self.gmat.values, dtype=torch.float32, device=device)
-
-        if apply_vmat:
-            vmat_tensor = torch.as_tensor(self.vmat.values, dtype=torch.float32, device=device)
-
-        cues_values = self.cmat.cues.values
-        n_cues = cues_values.size
-
-        # Phase 1 Optimization: Pre-allocate tensors on GPU (Strategy 4)
-        c_comp = torch.zeros(n_cues, dtype=torch.float32, device=device)
-        # Pre-allocate storage for indices and vectors on GPU
-        xs_indices = torch.zeros(max_attempt, dtype=torch.long, device=device)
-        vecs_gpu = torch.zeros((max_attempt, n_cues), dtype=torch.float32, device=device)
-
-        p_tensor = torch.tensor(-1, dtype=torch.long, device=device)
-        actual_iterations = 0
-
-        for i in range(max_attempt):
-            # Use in-place operations where possible (Strategy 4)
-            s0 = torch.matmul(c_comp, fmat_tensor)
-            if positive:
-                s0 = torch.clamp(s0, min=0)
-            s = gold_tensor - s0
-
-            if apply_vmat:
-                # Element-wise multiplication with vmat row
-                vmat_row = vmat_tensor[p_tensor]
-                g = gmat_tensor * vmat_row
-            else:
-                g = gmat_tensor
-
-            c_prod = torch.matmul(s, g)
-
-            # Check if all values are <= 0
-            if (c_prod <= 0).all():
-                break
-            else:
-                # Phase 1 Optimization: Keep argmax result as tensor (Strategy 3)
-                p_tensor = torch.argmax(c_prod)
-                # In-place update (Strategy 4)
-                c_comp[p_tensor] += 1
-
-                # Store index and vector on GPU (Strategy 2)
-                xs_indices[i] = p_tensor
-                vecs_gpu[i] = c_prod
-                actual_iterations = i + 1
-
-            # Phase 1 Optimization: Minimize synchronization (Strategy 3)
-            # Only sync when we need to check the cue string for ending condition
-            p_cpu = p_tensor.item()
-            selected_cue = cues_values[p_cpu]
-            is_unigram_onset = actual_iterations == 1 and len(selected_cue) == 1 and selected_cue == '#'
-            is_end = (selected_cue[-1] == '#') and (not is_unigram_onset)
-            is_max_iter = i == (max_attempt - 1)
-
-            if is_end or is_max_iter:
-                if is_max_iter:
-                    print('The maximum number of iterations ({:d}) reached.'.format(max_attempt))
-                break
-
-        # Phase 1 Optimization: Single GPU-to-CPU transfer at the end (Strategy 2)
-        xs_indices_cpu = xs_indices[:actual_iterations].cpu().numpy()
-        vecs_cpu = vecs_gpu[:actual_iterations].cpu().numpy()
-
-        # Convert indices to cue strings
-        xs = [cues_values[idx] for idx in xs_indices_cpu]
-
-        # Round vectors only at the end, not in every iteration
-        vecs = [v.round(roundby) for v in vecs_cpu]
-        df = pd.DataFrame(vecs).rename(columns={ i:j for i,j in enumerate(cues_values) })
-        hdr = pd.Series(xs).to_frame(name='Selected')
-        df = pd.concat([hdr, df], axis=1)
-        if word:
-            df = concat_cues(df.Selected)
-        return df
 
     def save_matrices (self, directory, add='', mats=None, compress=True):
         ext = '.csv.gz' if compress else '.csv'

--- a/discriminative_lexicon_model/ldl.py
+++ b/discriminative_lexicon_model/ldl.py
@@ -99,7 +99,7 @@ class LDL:
             self.gen_shat()
         return None
 
-    def produce (self, gold, word=False, roundby=10, max_attempt=50, positive=False, apply_vmat=True, backend='auto', device=None, stop='convergence'):
+    def produce (self, gold, word=False, roundby=10, max_attempt=50, positive=False, apply_vmat=True, backend='auto', device=None, stop='convergence', tol=0.0):
         """
         Produce output using discriminative learning.
 
@@ -126,13 +126,16 @@ class LDL:
             'torch' or 'auto', chooses 'cuda' if available, else 'cpu'.
         stop : {'convergence', 'boundary'}
             'convergence' -> Stop when no cue can improve the semantic
-                approximation (all c_prod values <= 0).
+                approximation (all c_prod values <= tol).
             'boundary' -> Also stop when a cue ending with '#' is selected.
+        tol : float
+            Tolerance for the convergence check. The algorithm stops when all
+            c_prod values are <= tol. Default is 0.0.
         """
         return lm.produce(gold, self.cmat, self.fmat, self.gmat, self.vmat,
                           word=word, roundby=roundby, max_attempt=max_attempt,
                           positive=positive, apply_vmat=apply_vmat,
-                          backend=backend, device=device, stop=stop)
+                          backend=backend, device=device, stop=stop, tol=tol)
 
     def produce_batch (self, gold_batch, word=False, roundby=10, max_attempt=50, positive=False, apply_vmat=True, backend='auto', device=None, batch_size=None):
         """

--- a/discriminative_lexicon_model/ldl.py
+++ b/discriminative_lexicon_model/ldl.py
@@ -99,7 +99,7 @@ class LDL:
             self.gen_shat()
         return None
 
-    def produce (self, gold, word=False, roundby=10, max_attempt=50, positive=False, apply_vmat=True, backend='auto', device=None):
+    def produce (self, gold, word=False, roundby=10, max_attempt=50, positive=False, apply_vmat=True, backend='auto', device=None, stop='convergence'):
         """
         Produce output using discriminative learning.
 
@@ -124,11 +124,15 @@ class LDL:
         device : str or None
             For torch backend: 'cuda', 'cpu', etc. If None and backend is
             'torch' or 'auto', chooses 'cuda' if available, else 'cpu'.
+        stop : {'convergence', 'boundary'}
+            'convergence' -> Stop when no cue can improve the semantic
+                approximation (all c_prod values <= 0).
+            'boundary' -> Also stop when a cue ending with '#' is selected.
         """
         return lm.produce(gold, self.cmat, self.fmat, self.gmat, self.vmat,
                           word=word, roundby=roundby, max_attempt=max_attempt,
                           positive=positive, apply_vmat=apply_vmat,
-                          backend=backend, device=device)
+                          backend=backend, device=device, stop=stop)
 
     def produce_batch (self, gold_batch, word=False, roundby=10, max_attempt=50, positive=False, apply_vmat=True, backend='auto', device=None, batch_size=None):
         """

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "discriminative_lexicon_model"
-version = "2.6.0"
+version = "2.7.0"
 description = "Python-implementation of Discriminative Lexicon Model / Linear Discriminative Learning"
 
 license = "MIT"


### PR DESCRIPTION
## Summary

Improve the `produce` algorithm by deduplicating code, adding configurable stopping criteria, and removing the hard dependency on `#` as a word boundary marker.

- **Delegate `LDL.produce` to `mapping.produce`**: Remove the duplicated `_produce_numpy` and `_produce_torch` methods from the `LDL` class, making `LDL.produce` a thin wrapper around `mapping.produce`.
- **Add `stop` parameter**: `stop='convergence'` (default) stops only when no cue can improve the semantic approximation; `stop='boundary'` also stops when a `#`-ending cue is selected, preserving the old behavior.
- **Add `tol` parameter**: Configurable tolerance (default 0.0) for the convergence check (`c_prod <= tol`), allowing users to filter out floating-point noise.
- **Add `_concat_selected` helper**: Replace all uses of `concat_cues` with `_concat_selected(selected, overlap)`, which supports both overlapping concatenation (V-matrix mode) and simple joining, removing the dependency on `#` in the concatenation logic.

All changes are propagated through `produce`, `gen_chat_produce`, `produce_paradigm`, and `LDL.produce`. Version bumped to 2.7.0.

## Test plan

- [x] Existing tests pass
- [x] New tests for `stop` parameter (convergence vs boundary, prefix property, both backends, invalid value)
- [x] New tests for `tol` parameter (default behavior, monotonicity, prefix property, negative tol, both backends)
- [x] New tests for `_concat_selected` (overlap/no-overlap modes, edge cases, backward compatibility with `concat_cues`)
- [x] Integration tests confirming `LDL.produce` matches `mapping.produce` for all parameter combinations
